### PR TITLE
Use libswresample-dev in favor of libavresample-dev, if available

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ $ sudo apt-get install \
     libogg-dev libspeex-dev libspeexdsp-dev \
     libldns-dev \
     python3-dev \
-    libavformat-dev libswscale-dev libavresample-dev \
+    libavformat-dev libswscale-dev 'libswresample-dev|libavresample-dev' \
     liblua5.2-dev \
     libopus-dev \
     libpq-dev \


### PR DESCRIPTION
`libavresample-dev` was part of the ffmpeg source package in Debian [bullseye](https://packages.debian.org/source/bullseye/ffmpeg), but is no longer available in [bookworm](https://packages.debian.org/source/bookworm/ffmpeg).  See [Debian bug #971318](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=971318) for more details.

This PR updates the set of build-deps to prefer `libswresample-dev` over `libavresample-dev`.