### PR TITLE
[GHA] Trigger FSE build on any `push` event

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,6 +50,7 @@ jobs:
     name: 'DEB-FSE'
     if: >-
       ${{
+        github.event_name == 'push' ||
         github.event.pull_request.head.repo.full_name == github.repository ||
         github.actor == github.repository_owner ||
         github.actor.belongs_to_organization ||


### PR DESCRIPTION
It seems that `github.event.pull_request.merged == true` is async event, push event branch is limited by trigger configuration.