### PR TITLE
[GHA] Use `push` event is trigger for publish

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -184,13 +184,7 @@ jobs:
       ${{
         (github.event.pull_request.head.repo.full_name == github.repository) &&
         (
-          (
-            github.event_name != 'workflow_dispatch' &&
-            (
-              github.event_name != 'pull_request' ||
-              (github.event_name == 'pull_request' && github.event.pull_request.merged == true)
-            )
-          ) ||
+          github.event_name == 'push' ||
           (github.event_name == 'workflow_dispatch' && inputs.publish)
         )
       }}


### PR DESCRIPTION
Similar to how FSE condition is working, use `push` event as publish condition, event branch is restricted by trigger conditions.