### PR TITLE
[GHA] Publish can only happen on manual trigger or on merge

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -182,11 +182,8 @@ jobs:
     name: 'Publish build data to meta-repo'
     if: >-
       ${{
-        (github.event.pull_request.head.repo.full_name == github.repository) &&
-        (
-          github.event_name == 'push' ||
-          (github.event_name == 'workflow_dispatch' && inputs.publish)
-        )
+        github.event_name == 'push' ||
+        (github.event_name == 'workflow_dispatch' && inputs.publish)
       }}
     needs:
       - deb-fse


### PR DESCRIPTION
We do not expect to publish packages on any kind of PR(s), removing this case due to redundancy and not working correctly in current implementation.