### PR TITLE
[comment]fix helptxt for connection-rx-buffer-size and connection-tx-…

### DIFF
--- a/mod_unimrcp.c
+++ b/mod_unimrcp.c
@@ -183,9 +183,9 @@ static switch_xml_config_item_t instructions[] = {
 	SWITCH_CONFIG_ITEM_STRING_STRDUP("request-timeout", CONFIG_REQUIRED, &globals.unimrcp_request_timeout, "10000", "",
 									 "Maximum time to wait for server response to a request"),
 	SWITCH_CONFIG_ITEM_STRING_STRDUP("connection-rx-buffer-size", 0, &globals.unimrcp_rx_buffer_size, "1024", "",
-									 "Maximum time to wait for server response to a request"),
+									 "MRCP connection receive buffer size in bytes"),
 	SWITCH_CONFIG_ITEM_STRING_STRDUP("connection-tx-buffer-size", 0, &globals.unimrcp_tx_buffer_size, "1024", "",
-									 "Maximum time to wait for server response to a request"),
+									 "MRCP connection transmit buffer size in bytes"),
 	SWITCH_CONFIG_ITEM_END()
 };
 


### PR DESCRIPTION
The helpText of these two configurations in the current code are wrong, both are written as "the maximum time to wait for the server to respond to a request"  mod_unimrcp.c:185-188, which is actually the description of the request-timeout configuration.