### PR TITLE
Allow Server-IP pointing to DNS, Load Balancing and Failover mechanism

### DIFF
--- a/mod_unimrcp.c
+++ b/mod_unimrcp.c
@@ -75,6 +75,9 @@ struct server_dispatcher {
 	char buffer[INET6_ADDRSTRLEN]; /**< written by get_next, sig_settings->server_ip points here */
 };
 
+/** Maximum number of failover retries (next server IP) when channel add fails; total attempts = 1 + this. */
+#define MAX_DISPATCHER_FAILOVER_RETRIES 3
+
 /*********************************************************************************************************************************************
  * mod_unimrcp : module interface to FreeSWITCH
  */
@@ -372,6 +375,8 @@ struct speech_channel {
 	audio_queue_t *audio_queue;
 	/** True, if channel was opened successfully */
 	int channel_opened;
+	/** Dispatcher failover: number of server IPs tried for this open (only when profile->server_dispatcher) */
+	int dispatcher_failover_attempts;
 	/** rate */
 	uint16_t rate;
 	/** silence sample */
@@ -396,6 +401,8 @@ static switch_status_t speech_channel_create(speech_channel_t ** schannel, const
 											 uint16_t rate, switch_memory_pool_t *pool);
 static mpf_termination_t *speech_channel_create_mpf_termination(speech_channel_t *schannel);
 static switch_status_t speech_channel_open(speech_channel_t *schannel, profile_t *profile);
+/** Used only for dispatcher failover retry (create session + add channel to next IP). */
+static switch_status_t speech_channel_connect_next(speech_channel_t *schannel, profile_t *profile);
 static switch_status_t speech_channel_destroy(speech_channel_t *schannel);
 static switch_status_t speech_channel_stop(speech_channel_t *schannel);
 static switch_status_t speech_channel_set_param(speech_channel_t *schannel, const char *name, const char *val);
@@ -911,6 +918,7 @@ static switch_status_t speech_channel_create(speech_channel_t ** schannel, const
 	schan->rate = rate;
 	schan->silence = 0;			/* L16 silence sample */
 	schan->channel_opened = 0;
+	schan->dispatcher_failover_attempts = 0;
 
 	apr_pool_create(&schan->apr_pool, NULL);
 
@@ -1039,9 +1047,10 @@ static switch_status_t speech_channel_open(speech_channel_t *schannel, profile_t
 
 	schannel->profile = profile;
 
-	/* per-connection load balancing: pick next server IP (DNS resolved, 10-min cache, round-robin) */
+	/* per-connection load balancing: pick next server IP (only when dispatcher is defined) */
 	if (profile->server_dispatcher) {
 		server_dispatcher_get_next(profile->server_dispatcher);
+		schannel->dispatcher_failover_attempts = 1;
 	}
 
 	/* create MRCP session */
@@ -1947,6 +1956,27 @@ static apt_bool_t speech_on_channel_add(mrcp_application_t *application, mrcp_se
 
 error:
 	if (schannel) {
+		/* Failover: when dispatcher is defined, try next server IP before giving up */
+		if (schannel->profile && schannel->profile->server_dispatcher) {
+			server_dispatcher_t *d = schannel->profile->server_dispatcher;
+			if (schannel->dispatcher_failover_attempts < (int)d->ips->nelts &&
+				schannel->dispatcher_failover_attempts < (1 + MAX_DISPATCHER_FAILOVER_RETRIES)) {
+				schannel->dispatcher_failover_attempts++;
+				switch_log_printf(SWITCH_CHANNEL_UUID_LOG(schannel->session_uuid), SWITCH_LOG_INFO,
+					"(%s) %s channel add failed, failover to next server IP (attempt %d/%d)\n",
+					schannel->name, speech_channel_type_to_string(schannel->type),
+					schannel->dispatcher_failover_attempts, (int)d->ips->nelts);
+				server_dispatcher_get_next(d);
+				if (session) {
+					mrcp_application_session_destroy(session);
+				}
+				schannel->unimrcp_session = NULL;
+				schannel->unimrcp_channel = NULL;
+				if (speech_channel_connect_next(schannel, schannel->profile) == SWITCH_STATUS_SUCCESS) {
+					return TRUE;
+				}
+			}
+		}
 		switch_log_printf(SWITCH_CHANNEL_UUID_LOG(schannel->session_uuid), SWITCH_LOG_ERROR, "(%s) %s channel error!\n", schannel->name,
 			speech_channel_type_to_string(schannel->type));
 		speech_channel_set_state(schannel, SPEECH_CHANNEL_ERROR);
@@ -1957,6 +1987,59 @@ error:
 	return TRUE;
 }
 
+/**
+ * Connect to next server IP (dispatcher failover only).
+ * Creates new MRCP session, termination, channel and adds channel; called from speech_on_channel_add error path.
+ * Caller does not hold schannel->mutex.
+ */
+static switch_status_t speech_channel_connect_next(speech_channel_t *schannel, profile_t *profile)
+{
+	switch_status_t status = SWITCH_STATUS_SUCCESS;
+	mpf_termination_t *termination = NULL;
+	mrcp_resource_type_e resource_type;
+
+	switch_mutex_lock(schannel->mutex);
+
+	if ((schannel->unimrcp_session = mrcp_application_session_create(schannel->application->app, profile->name, schannel)) == NULL) {
+		switch_log_printf(SWITCH_CHANNEL_UUID_LOG(schannel->session_uuid), SWITCH_LOG_ERROR, "(%s) Unable to create session with %s (failover)\n", schannel->name, profile->name);
+		status = SWITCH_STATUS_FALSE;
+		goto done;
+	}
+	mrcp_application_session_name_set(schannel->unimrcp_session, schannel->name);
+
+	if ((termination = speech_channel_create_mpf_termination(schannel)) == NULL) {
+		switch_log_printf(SWITCH_CHANNEL_UUID_LOG(schannel->session_uuid), SWITCH_LOG_ERROR, "(%s) Unable to create termination with %s (failover)\n", schannel->name, profile->name);
+		mrcp_application_session_destroy(schannel->unimrcp_session);
+		schannel->unimrcp_session = NULL;
+		status = SWITCH_STATUS_FALSE;
+		goto done;
+	}
+	if (schannel->type == SPEECH_CHANNEL_SYNTHESIZER) {
+		resource_type = MRCP_SYNTHESIZER_RESOURCE;
+	} else {
+		resource_type = MRCP_RECOGNIZER_RESOURCE;
+	}
+	if ((schannel->unimrcp_channel = mrcp_application_channel_create(schannel->unimrcp_session, resource_type, termination, NULL, schannel)) == NULL) {
+		switch_log_printf(SWITCH_CHANNEL_UUID_LOG(schannel->session_uuid), SWITCH_LOG_ERROR, "(%s) Unable to create channel with %s (failover)\n", schannel->name, profile->name);
+		mrcp_application_session_destroy(schannel->unimrcp_session);
+		schannel->unimrcp_session = NULL;
+		status = SWITCH_STATUS_FALSE;
+		goto done;
+	}
+
+	if (mrcp_application_channel_add(schannel->unimrcp_session, schannel->unimrcp_channel) != TRUE) {
+		switch_log_printf(SWITCH_CHANNEL_UUID_LOG(schannel->session_uuid), SWITCH_LOG_ERROR, "(%s) Unable to add channel to session with %s (failover)\n", schannel->name, profile->name);
+		mrcp_application_session_destroy(schannel->unimrcp_session);
+		schannel->unimrcp_session = NULL;
+		schannel->unimrcp_channel = NULL;
+		status = SWITCH_STATUS_FALSE;
+		goto done;
+	}
+
+  done:
+	switch_mutex_unlock(schannel->mutex);
+	return status;
+}
 
 /**
  * Handle the UniMRCP responses sent to channel remove requests

--- a/mod_unimrcp.c
+++ b/mod_unimrcp.c
@@ -4139,7 +4139,7 @@ static server_dispatcher_t *server_dispatcher_create(const char *value, apr_pool
 	if (!d->ips) {
 		return NULL;
 	}
-	if (switch_mutex_create(&d->mutex, SWITCH_MUTEX_NESTED, mod_pool) != SWITCH_STATUS_SUCCESS) {
+	if (switch_mutex_init(&d->mutex, SWITCH_MUTEX_NESTED, mod_pool) != SWITCH_STATUS_SUCCESS) {
 		return NULL;
 	}
 	d->buffer[0] = '\0';

--- a/mod_unimrcp.c
+++ b/mod_unimrcp.c
@@ -64,9 +64,6 @@
 #include <netinet/in.h>
 #include <arpa/inet.h>
 
-/** DNS cache TTL for server-ip dispatcher (10 minutes), in APR usec */
-#define SERVER_DISPATCHER_DNS_CACHE_TTL_USEC (600 * APR_USEC_PER_SEC)
-
 /** Server IP dispatcher: load-balances connections across all IPs resolved from server-ip (DNS or list) */
 typedef struct server_dispatcher server_dispatcher_t;
 struct server_dispatcher {
@@ -74,7 +71,6 @@ struct server_dispatcher {
 	apr_pool_t *pool;              /**< pool for ips and re-resolve allocations */
 	apr_array_header_t *ips;       /**< (char*) IP list from DNS or single IP */
 	apr_uint32_t next_index;
-	apr_time_t cache_expiry;       /**< next re-resolve time (APR usec) */
 	switch_mutex_t *mutex;
 	char buffer[INET6_ADDRSTRLEN]; /**< written by get_next, sig_settings->server_ip points here */
 };
@@ -4039,7 +4035,7 @@ static char *server_addr_get(const char *value, apr_pool_t *pool)
 
 /**
  * Resolve hostname to all IPv4 addresses and fill dispatcher->ips.
- * Uses getaddrinfo; cache is valid for SERVER_DISPATCHER_DNS_CACHE_TTL_SEC.
+ * Called once at profile load; result is cached until module reload.
  */
 static void server_dispatcher_resolve(server_dispatcher_t *dispatcher)
 {
@@ -4055,7 +4051,6 @@ static void server_dispatcher_resolve(server_dispatcher_t *dispatcher)
 		char *addr = DEFAULT_REMOTE_IP_ADDRESS;
 		apt_ip_get(&addr, dispatcher->pool);
 		*(const char **)apr_array_push(dispatcher->ips) = apr_pstrdup(dispatcher->pool, addr);
-		dispatcher->cache_expiry = apr_time_now() + SERVER_DISPATCHER_DNS_CACHE_TTL_USEC;
 		return;
 	}
 
@@ -4069,7 +4064,6 @@ static void server_dispatcher_resolve(server_dispatcher_t *dispatcher)
 		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING,
 			"server-ip: unable to resolve '%s' (%s), using as single destination\n", node, gai_strerror(gaierr));
 		*(const char **)apr_array_push(dispatcher->ips) = apr_pstrdup(dispatcher->pool, node);
-		dispatcher->cache_expiry = apr_time_now() + SERVER_DISPATCHER_DNS_CACHE_TTL_USEC;
 		return;
 	}
 
@@ -4089,7 +4083,6 @@ static void server_dispatcher_resolve(server_dispatcher_t *dispatcher)
 			"server-ip: no IPv4 addresses for '%s', using hostname as-is\n", node);
 		*(const char **)apr_array_push(dispatcher->ips) = apr_pstrdup(dispatcher->pool, node);
 	}
-	dispatcher->cache_expiry = apr_time_now() + SERVER_DISPATCHER_DNS_CACHE_TTL_USEC;
 }
 
 /**
@@ -4115,7 +4108,7 @@ static int server_ip_is_hostname(const char *value)
 
 /**
  * Create a server IP dispatcher for load balancing per connection (DNS only).
- * Value must be a hostname or "auto"; resolved to all IPs with 10-min cache and round-robin.
+ * Value must be a hostname or "auto"; resolved once at load, round-robin per connection (reload to refresh DNS).
  *
  * @param value server-ip param value (hostname or "auto")
  * @param pool APR pool for dispatcher and IP strings
@@ -4143,7 +4136,6 @@ static server_dispatcher_t *server_dispatcher_create(const char *value, apr_pool
 		return NULL;
 	}
 	d->buffer[0] = '\0';
-	d->cache_expiry = 0;
 	d->next_index = 0;
 
 	server_dispatcher_resolve(d);
@@ -4157,21 +4149,16 @@ static server_dispatcher_t *server_dispatcher_create(const char *value, apr_pool
 
 /**
  * Get next server IP for a new connection (round-robin) and write it into dispatcher->buffer.
- * Re-resolves DNS after SERVER_DISPATCHER_DNS_CACHE_TTL_SEC.
+ * Uses cached DNS result from profile load; reload module to refresh (no expiration).
  */
 static void server_dispatcher_get_next(server_dispatcher_t *dispatcher)
 {
-	apr_time_t now;
 	const char *ip;
 
 	if (!dispatcher || !dispatcher->mutex) {
 		return;
 	}
 	switch_mutex_lock(dispatcher->mutex);
-	now = apr_time_now();
-	if (dispatcher->ips->nelts == 0 || now >= dispatcher->cache_expiry) {
-		server_dispatcher_resolve(dispatcher);
-	}
 	if (dispatcher->ips->nelts > 0) {
 		ip = APR_ARRAY_IDX(dispatcher->ips, dispatcher->next_index % (apr_uint32_t)dispatcher->ips->nelts, const char *);
 		dispatcher->next_index++;

--- a/mod_unimrcp.c
+++ b/mod_unimrcp.c
@@ -224,6 +224,7 @@ static int process_rtp_config(mrcp_client_t *client, mpf_rtp_config_t *rtp_confi
 static int process_mrcpv1_config(rtsp_client_config_t *config, mrcp_sig_settings_t *sig_settings, const char *param, const char *val, apr_pool_t *pool);
 static int process_mrcpv2_config(mrcp_sofia_client_config_t *config, mrcp_sig_settings_t *sig_settings, const char *param, const char *val, apr_pool_t *pool);
 static int process_profile_config(profile_t *profile, const char *param, const char *val, switch_memory_pool_t *pool);
+static void server_dispatcher_get_next(server_dispatcher_t *dispatcher);
 
 /* UniMRCP <--> FreeSWITCH logging bridge */
 static apt_bool_t unimrcp_log(const char *file, int line, const char *obj, apt_log_priority_e priority, const char *format, va_list arg_ptr);

--- a/mod_unimrcp.c
+++ b/mod_unimrcp.c
@@ -3971,6 +3971,44 @@ static char *ip_addr_get(const char *value, apr_pool_t *pool)
 }
 
 /**
+ * Get server IP address from value (supports both IP address and DNS name)
+ * Resolves DNS names to IP addresses using APR
+ *
+ * @param value "auto", IP address, or DNS name
+ * @param pool the memory pool to use
+ * @return IP address (resolved from DNS if needed)
+ */
+static char *server_addr_get(const char *value, apr_pool_t *pool)
+{
+    apr_sockaddr_t *sockaddr = NULL;
+    char *ip_addr = NULL;
+    apr_status_t status;
+
+    if (!value || strcasecmp(value, "auto") == 0) {
+        ip_addr = DEFAULT_REMOTE_IP_ADDRESS;
+        apt_ip_get(&ip_addr, pool);
+        return ip_addr;
+    }
+
+    status = apr_sockaddr_info_get(&sockaddr, value, APR_INET, 0, 0, pool);
+
+    if (status != APR_SUCCESS) {
+        switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING,
+            "Unable to resolve '%s' (%d), returning as-is\n", value, status);
+        return apr_pstrdup(pool, value);
+    }
+
+    status = apr_sockaddr_ip_get(&ip_addr, sockaddr);
+    if (status != APR_SUCCESS) {
+        switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING,
+            "apr_sockaddr_ip_get failed for '%s' (%d), using as-is\n", value, status);
+        return apr_pstrdup(pool, value);
+    }
+
+    return ip_addr;
+}
+
+/**
  * set mod_unimrcp-specific profile configuration
  *
  * @param profile the MRCP profile to configure
@@ -4059,7 +4097,7 @@ static int process_mrcpv1_config(rtsp_client_config_t *config, mrcp_sig_settings
 {
 	int mine = 1;
 	if (strcasecmp(param, "server-ip") == 0) {
-		sig_settings->server_ip = ip_addr_get(val, pool);
+		sig_settings->server_ip = server_addr_get(val, pool);
 	} else if (strcasecmp(param, "server-port") == 0) {
 		sig_settings->server_port = (apr_port_t) atol(val);
 	} else if (strcasecmp(param, "resource-location") == 0) {
@@ -4097,7 +4135,7 @@ static int process_mrcpv2_config(mrcp_sofia_client_config_t *config, mrcp_sig_se
 	} else if (strcasecmp(param, "client-port") == 0) {
 		config->local_port = (apr_port_t) atol(val);
 	} else if (strcasecmp(param, "server-ip") == 0) {
-		sig_settings->server_ip = ip_addr_get(val, pool);
+		sig_settings->server_ip = server_addr_get(val, pool);
 	} else if (strcasecmp(param, "server-port") == 0) {
 		sig_settings->server_port = (apr_port_t) atol(val);
 	} else if (strcasecmp(param, "server-username") == 0) {

--- a/mod_unimrcp.c
+++ b/mod_unimrcp.c
@@ -220,8 +220,9 @@ SWITCH_MODULE_DEFINITION(mod_unimrcp, mod_unimrcp_load, mod_unimrcp_shutdown, NU
 static switch_status_t mod_unimrcp_do_config();
 static mrcp_client_t *mod_unimrcp_client_create(switch_memory_pool_t *mod_pool);
 static int process_rtp_config(mrcp_client_t *client, mpf_rtp_config_t *rtp_config, mpf_rtp_settings_t *rtp_settings, const char *param, const char *val, apr_pool_t *pool);
-static int process_mrcpv1_config(rtsp_client_config_t *config, mrcp_sig_settings_t *sig_settings, const char *param, const char *val, apr_pool_t *pool);
-static int process_mrcpv2_config(mrcp_sofia_client_config_t *config, mrcp_sig_settings_t *sig_settings, const char *param, const char *val, apr_pool_t *pool);
+static void process_server_ip_param(mrcp_sig_settings_t *sig_settings, profile_t *mod_profile, const char *val, apr_pool_t *pool, switch_memory_pool_t *mod_pool);
+static int process_mrcpv1_config(rtsp_client_config_t *config, mrcp_sig_settings_t *sig_settings, profile_t *mod_profile, const char *param, const char *val, apr_pool_t *pool, switch_memory_pool_t *mod_pool);
+static int process_mrcpv2_config(mrcp_sofia_client_config_t *config, mrcp_sig_settings_t *sig_settings, profile_t *mod_profile, const char *param, const char *val, apr_pool_t *pool, switch_memory_pool_t *mod_pool);
 static int process_profile_config(profile_t *profile, const char *param, const char *val, switch_memory_pool_t *pool);
 static void server_dispatcher_get_next(server_dispatcher_t *dispatcher);
 
@@ -4327,19 +4328,40 @@ static int process_rtp_config(mrcp_client_t *client, mpf_rtp_config_t *rtp_confi
 }
 
 /**
+ * Handle server-ip param: dispatcher (hostname) or single IP via server_addr_get.
+ * Sets sig_settings->server_ip and optionally mod_profile->server_dispatcher.
+ */
+static void process_server_ip_param(mrcp_sig_settings_t *sig_settings, profile_t *mod_profile, const char *val, apr_pool_t *pool, switch_memory_pool_t *mod_pool)
+{
+	if (server_ip_is_hostname(val)) {
+		server_dispatcher_t *d = server_dispatcher_create(val, pool, mod_pool);
+		if (d) {
+			mod_profile->server_dispatcher = d;
+			sig_settings->server_ip = d->buffer;
+		} else {
+			sig_settings->server_ip = server_addr_get(val, pool);
+		}
+	} else {
+		sig_settings->server_ip = server_addr_get(val, pool);
+	}
+}
+
+/**
  * set RTSP client config struct with param, val pair
  * @param config the config struct to set
  * @param sig_settings the sig settings struct to set
+ * @param mod_profile mod_unimrcp profile (for server_dispatcher when server-ip is hostname)
  * @param param the param name
  * @param val the param value
  * @param pool memory pool to use
+ * @param mod_pool switch pool for dispatcher mutex
  * @return true if this param belongs to RTSP config
  */
-static int process_mrcpv1_config(rtsp_client_config_t *config, mrcp_sig_settings_t *sig_settings, const char *param, const char *val, apr_pool_t *pool)
+static int process_mrcpv1_config(rtsp_client_config_t *config, mrcp_sig_settings_t *sig_settings, profile_t *mod_profile, const char *param, const char *val, apr_pool_t *pool, switch_memory_pool_t *mod_pool)
 {
 	int mine = 1;
 	if (strcasecmp(param, "server-ip") == 0) {
-		sig_settings->server_ip = server_addr_get(val, pool);
+		process_server_ip_param(sig_settings, mod_profile, val, pool, mod_pool);
 	} else if (strcasecmp(param, "server-port") == 0) {
 		sig_settings->server_port = (apr_port_t) atol(val);
 	} else if (strcasecmp(param, "resource-location") == 0) {
@@ -4362,12 +4384,14 @@ static int process_mrcpv1_config(rtsp_client_config_t *config, mrcp_sig_settings
  * set SofiaSIP client config struct with param, val pair
  * @param config the config struct to set
  * @param sig_settings the sig settings struct to set
+ * @param mod_profile mod_unimrcp profile (for server_dispatcher when server-ip is hostname)
  * @param param the param name
  * @param val the param value
  * @param pool memory pool to use
+ * @param mod_pool switch pool for dispatcher mutex
  * @return true if this param belongs to SofiaSIP config
  */
-static int process_mrcpv2_config(mrcp_sofia_client_config_t *config, mrcp_sig_settings_t *sig_settings, const char *param, const char *val, apr_pool_t *pool)
+static int process_mrcpv2_config(mrcp_sofia_client_config_t *config, mrcp_sig_settings_t *sig_settings, profile_t *mod_profile, const char *param, const char *val, apr_pool_t *pool, switch_memory_pool_t *mod_pool)
 {
 	int mine = 1;
 	if (strcasecmp(param, "client-ip") == 0) {
@@ -4377,7 +4401,7 @@ static int process_mrcpv2_config(mrcp_sofia_client_config_t *config, mrcp_sig_se
 	} else if (strcasecmp(param, "client-port") == 0) {
 		config->local_port = (apr_port_t) atol(val);
 	} else if (strcasecmp(param, "server-ip") == 0) {
-		sig_settings->server_ip = server_addr_get(val, pool);
+		process_server_ip_param(sig_settings, mod_profile, val, pool, mod_pool);
 	} else if (strcasecmp(param, "server-port") == 0) {
 		sig_settings->server_port = (apr_port_t) atol(val);
 	} else if (strcasecmp(param, "server-username") == 0) {
@@ -4638,21 +4662,7 @@ static mrcp_client_t *mod_unimrcp_client_create(switch_memory_pool_t *mod_pool)
 						goto done;
 					}
 					switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "Loading Param %s:%s\n", param_name, param_value);
-					if (strcasecmp(param_name, "server-ip") == 0) {
-						if (server_ip_is_hostname(param_value)) {
-							server_dispatcher_t *d = server_dispatcher_create(param_value, pool, mod_pool);
-							if (d) {
-								mod_profile->server_dispatcher = d;
-								sig_settings->server_ip = d->buffer;
-							} else {
-								sig_settings->server_ip = server_addr_get(param_value, pool);
-							}
-						} else {
-							sig_settings->server_ip = server_addr_get(param_value, pool);
-						}
-						continue;
-					}
-					if (!process_mrcpv1_config(config, sig_settings, param_name, param_value, pool) &&
+					if (!process_mrcpv1_config(config, sig_settings, mod_profile, param_name, param_value, pool, mod_pool) &&
 						!process_rtp_config(client, rtp_config, rtp_settings, param_name, param_value, pool) &&
 						!process_profile_config(mod_profile, param_name, param_value, mod_pool)) {
 						switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING, "Ignoring unknown param %s\n", param_name);
@@ -4686,21 +4696,7 @@ static mrcp_client_t *mod_unimrcp_client_create(switch_memory_pool_t *mod_pool)
 						goto done;
 					}
 					switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "Loading Param %s:%s\n", param_name, param_value);
-					if (strcasecmp(param_name, "server-ip") == 0) {
-						if (server_ip_is_hostname(param_value)) {
-							server_dispatcher_t *d = server_dispatcher_create(param_value, pool, mod_pool);
-							if (d) {
-								mod_profile->server_dispatcher = d;
-								sig_settings->server_ip = d->buffer;
-							} else {
-								sig_settings->server_ip = server_addr_get(param_value, pool);
-							}
-						} else {
-							sig_settings->server_ip = server_addr_get(param_value, pool);
-						}
-						continue;
-					}
-					if (!process_mrcpv2_config(config, sig_settings, param_name, param_value, pool) &&
+					if (!process_mrcpv2_config(config, sig_settings, mod_profile, param_name, param_value, pool, mod_pool) &&
 						!process_rtp_config(client, rtp_config, rtp_settings, param_name, param_value, pool) &&
 						!process_profile_config(mod_profile, param_name, param_value, mod_pool)) {
 						switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING, "Ignoring unknown param %s\n", param_name);

--- a/mod_unimrcp.c
+++ b/mod_unimrcp.c
@@ -58,6 +58,27 @@
 #include "mrcp_client_connection.h"
 #include "apt_net.h"
 
+/* For server_dispatcher_resolve(): getaddrinfo(), inet_ntop(); APR has no "resolve all IPs" API */
+#include <netdb.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+
+/** DNS cache TTL for server-ip dispatcher (10 minutes), in APR usec */
+#define SERVER_DISPATCHER_DNS_CACHE_TTL_USEC (600 * APR_USEC_PER_SEC)
+
+/** Server IP dispatcher: load-balances connections across all IPs resolved from server-ip (DNS or list) */
+typedef struct server_dispatcher server_dispatcher_t;
+struct server_dispatcher {
+	const char *hostname;
+	apr_pool_t *pool;              /**< pool for ips and re-resolve allocations */
+	apr_array_header_t *ips;       /**< (char*) IP list from DNS or single IP */
+	apr_uint32_t next_index;
+	apr_time_t cache_expiry;       /**< next re-resolve time (APR usec) */
+	switch_mutex_t *mutex;
+	char buffer[INET6_ADDRSTRLEN]; /**< written by get_next, sig_settings->server_ip points here */
+};
+
 /*********************************************************************************************************************************************
  * mod_unimrcp : module interface to FreeSWITCH
  */
@@ -156,6 +177,8 @@ struct profile {
 	switch_hash_t *default_recog_params;
 	/** Default params to use for SPEAK requests */
 	switch_hash_t *default_synth_params;
+	/** Optional load-balancing dispatcher for server-ip (DNS → multiple IPs, round-robin per connection) */
+	server_dispatcher_t *server_dispatcher;
 };
 typedef struct profile profile_t;
 static switch_status_t profile_create(profile_t ** profile, const char *name, switch_memory_pool_t *pool);
@@ -1018,6 +1041,11 @@ static switch_status_t speech_channel_open(speech_channel_t *schannel, profile_t
 	}
 
 	schannel->profile = profile;
+
+	/* per-connection load balancing: pick next server IP (DNS resolved, 10-min cache, round-robin) */
+	if (profile->server_dispatcher) {
+		server_dispatcher_get_next(profile->server_dispatcher);
+	}
 
 	/* create MRCP session */
 	if ((schannel->unimrcp_session = mrcp_application_session_create(schannel->application->app, profile->name, schannel)) == NULL) {
@@ -4009,6 +4037,149 @@ static char *server_addr_get(const char *value, apr_pool_t *pool)
 }
 
 /**
+ * Resolve hostname to all IPv4 addresses and fill dispatcher->ips.
+ * Uses getaddrinfo; cache is valid for SERVER_DISPATCHER_DNS_CACHE_TTL_SEC.
+ */
+static void server_dispatcher_resolve(server_dispatcher_t *dispatcher)
+{
+	struct addrinfo hints;
+	struct addrinfo *res = NULL;
+	const char *node = dispatcher->hostname;
+	int gaierr;
+
+	/* Clear logical list so new resolve overwrites; storage reused */
+	dispatcher->ips->nelts = 0;
+
+	if (!node || strcasecmp(node, "auto") == 0) {
+		char *addr = DEFAULT_REMOTE_IP_ADDRESS;
+		apt_ip_get(&addr, dispatcher->pool);
+		*(const char **)apr_array_push(dispatcher->ips) = apr_pstrdup(dispatcher->pool, addr);
+		dispatcher->cache_expiry = apr_time_now() + SERVER_DISPATCHER_DNS_CACHE_TTL_USEC;
+		return;
+	}
+
+	memset(&hints, 0, sizeof(hints));
+	hints.ai_family = AF_INET;
+	hints.ai_socktype = SOCK_STREAM;
+	hints.ai_flags = AI_ADDRCONFIG;
+
+	gaierr = getaddrinfo(node, NULL, &hints, &res);
+	if (gaierr != 0) {
+		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING,
+			"server-ip: unable to resolve '%s' (%s), using as single destination\n", node, gai_strerror(gaierr));
+		*(const char **)apr_array_push(dispatcher->ips) = apr_pstrdup(dispatcher->pool, node);
+		dispatcher->cache_expiry = apr_time_now() + SERVER_DISPATCHER_DNS_CACHE_TTL_USEC;
+		return;
+	}
+
+	for (struct addrinfo *p = res; p != NULL; p = p->ai_next) {
+		if (p->ai_family == AF_INET && p->ai_addr != NULL) {
+			char buf[INET_ADDRSTRLEN];
+			struct sockaddr_in *sin = (struct sockaddr_in *)p->ai_addr;
+			if (inet_ntop(AF_INET, &sin->sin_addr, buf, sizeof(buf)) != NULL) {
+				*(const char **)apr_array_push(dispatcher->ips) = apr_pstrdup(dispatcher->pool, buf);
+			}
+		}
+	}
+	freeaddrinfo(res);
+
+	if (dispatcher->ips->nelts == 0) {
+		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING,
+			"server-ip: no IPv4 addresses for '%s', using hostname as-is\n", node);
+		*(const char **)apr_array_push(dispatcher->ips) = apr_pstrdup(dispatcher->pool, node);
+	}
+	dispatcher->cache_expiry = apr_time_now() + SERVER_DISPATCHER_DNS_CACHE_TTL_USEC;
+}
+
+/**
+ * Return true if server-ip value is a DNS hostname (dispatcher logic); false for plain IP or "auto" (use old logic, resolve to IP).
+ */
+static int server_ip_is_hostname(const char *value)
+{
+	const char *p;
+	if (!value || !*value) {
+		return 0;
+	}
+	/* "auto" must resolve to an IP via old logic, not dispatcher */
+	if (strcasecmp(value, "auto") == 0) {
+		return 0;
+	}
+	for (p = value; *p; p++) {
+		if ((*p >= 'a' && *p <= 'z') || (*p >= 'A' && *p <= 'Z') || *p == '-') {
+			return 1;
+		}
+	}
+	return 0;
+}
+
+/**
+ * Create a server IP dispatcher for load balancing per connection (DNS only).
+ * Value must be a hostname or "auto"; resolved to all IPs with 10-min cache and round-robin.
+ *
+ * @param value server-ip param value (hostname or "auto")
+ * @param pool APR pool for dispatcher and IP strings
+ * @param mod_pool switch pool for mutex
+ * @return dispatcher, or NULL on failure
+ */
+static server_dispatcher_t *server_dispatcher_create(const char *value, apr_pool_t *pool, switch_memory_pool_t *mod_pool)
+{
+	server_dispatcher_t *d;
+	const char *hostname;
+
+	hostname = (!value || !*value) ? DEFAULT_REMOTE_IP_ADDRESS : (strcasecmp(value, "auto") == 0 ? "auto" : value);
+
+	d = apr_pcalloc(pool, sizeof(*d));
+	if (!d) {
+		return NULL;
+	}
+	d->pool = pool;
+	d->hostname = apr_pstrdup(pool, hostname);
+	d->ips = apr_array_make(pool, 4, sizeof(const char *));
+	if (!d->ips) {
+		return NULL;
+	}
+	if (switch_mutex_create(&d->mutex, SWITCH_MUTEX_NESTED, mod_pool) != SWITCH_STATUS_SUCCESS) {
+		return NULL;
+	}
+	d->buffer[0] = '\0';
+	d->cache_expiry = 0;
+	d->next_index = 0;
+
+	server_dispatcher_resolve(d);
+
+	if (d->ips->nelts > 0) {
+		const char *first = APR_ARRAY_IDX(d->ips, 0, const char *);
+		apr_cpystrn(d->buffer, first, sizeof(d->buffer));
+	}
+	return d;
+}
+
+/**
+ * Get next server IP for a new connection (round-robin) and write it into dispatcher->buffer.
+ * Re-resolves DNS after SERVER_DISPATCHER_DNS_CACHE_TTL_SEC.
+ */
+static void server_dispatcher_get_next(server_dispatcher_t *dispatcher)
+{
+	apr_time_t now;
+	const char *ip;
+
+	if (!dispatcher || !dispatcher->mutex) {
+		return;
+	}
+	switch_mutex_lock(dispatcher->mutex);
+	now = apr_time_now();
+	if (dispatcher->ips->nelts == 0 || now >= dispatcher->cache_expiry) {
+		server_dispatcher_resolve(dispatcher);
+	}
+	if (dispatcher->ips->nelts > 0) {
+		ip = APR_ARRAY_IDX(dispatcher->ips, dispatcher->next_index % (apr_uint32_t)dispatcher->ips->nelts, const char *);
+		dispatcher->next_index++;
+		apr_cpystrn(dispatcher->buffer, ip, sizeof(dispatcher->buffer));
+	}
+	switch_mutex_unlock(dispatcher->mutex);
+}
+
+/**
  * set mod_unimrcp-specific profile configuration
  *
  * @param profile the MRCP profile to configure
@@ -4396,6 +4567,20 @@ static mrcp_client_t *mod_unimrcp_client_create(switch_memory_pool_t *mod_pool)
 						goto done;
 					}
 					switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "Loading Param %s:%s\n", param_name, param_value);
+					if (strcasecmp(param_name, "server-ip") == 0) {
+						if (server_ip_is_hostname(param_value)) {
+							server_dispatcher_t *d = server_dispatcher_create(param_value, pool, mod_pool);
+							if (d) {
+								mod_profile->server_dispatcher = d;
+								sig_settings->server_ip = d->buffer;
+							} else {
+								sig_settings->server_ip = server_addr_get(param_value, pool);
+							}
+						} else {
+							sig_settings->server_ip = server_addr_get(param_value, pool);
+						}
+						continue;
+					}
 					if (!process_mrcpv1_config(config, sig_settings, param_name, param_value, pool) &&
 						!process_rtp_config(client, rtp_config, rtp_settings, param_name, param_value, pool) &&
 						!process_profile_config(mod_profile, param_name, param_value, mod_pool)) {
@@ -4430,6 +4615,20 @@ static mrcp_client_t *mod_unimrcp_client_create(switch_memory_pool_t *mod_pool)
 						goto done;
 					}
 					switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "Loading Param %s:%s\n", param_name, param_value);
+					if (strcasecmp(param_name, "server-ip") == 0) {
+						if (server_ip_is_hostname(param_value)) {
+							server_dispatcher_t *d = server_dispatcher_create(param_value, pool, mod_pool);
+							if (d) {
+								mod_profile->server_dispatcher = d;
+								sig_settings->server_ip = d->buffer;
+							} else {
+								sig_settings->server_ip = server_addr_get(param_value, pool);
+							}
+						} else {
+							sig_settings->server_ip = server_addr_get(param_value, pool);
+						}
+						continue;
+					}
 					if (!process_mrcpv2_config(config, sig_settings, param_name, param_value, pool) &&
 						!process_rtp_config(client, rtp_config, rtp_settings, param_name, param_value, pool) &&
 						!process_profile_config(mod_profile, param_name, param_value, mod_pool)) {


### PR DESCRIPTION
Idea:

- Allow DNS on `server-ip` parameter;
  - If `auto` or static IP is declared, old logic will be used; 
- Load Balancing per connection;
- DNS failover logic (max retries 3);
